### PR TITLE
Add python interface to add/remove bullet objects and get/set rope states (does this break abstraction?)

### DIFF
--- a/src/simulation/bulletsim_lite.cpp
+++ b/src/simulation/bulletsim_lite.cpp
@@ -529,6 +529,10 @@ void BulletEnvironment::RemoveConstraint(BulletConstraint::Ptr cnt) {
   m_env->removeConstraint(cnt);
 }
 
+void BulletEnvironment::Remove(BulletObjectPtr obj) {
+  m_env->remove(obj->m_obj);
+}
+
 
 
 

--- a/src/simulation/bulletsim_lite.h
+++ b/src/simulation/bulletsim_lite.h
@@ -125,6 +125,7 @@ public:
   void RemoveConstraint(BulletConstraint::Ptr cnt);
 
   void Remove(BulletObjectPtr obj);
+  void Add(BulletObjectPtr obj);
 
 private:
   Environment::Ptr m_env;
@@ -156,11 +157,17 @@ public:
   std::vector<btVector3> GetNodes();
   std::vector<btVector3> GetControlPoints();
   vector<btMatrix3x3> GetRotations();
+  void SetRotations(py::object rots);
+  vector<btVector3> GetTranslations();
+  void SetTranslations(py::object trans);
   vector<float> GetHalfHeights();
 
   py::object py_GetNodes();
   py::object py_GetControlPoints();
   py::object py_GetRotations();
+  void py_SetRotations(py::object py_rots);
+  py::object py_GetTranslations();
+  void py_SetTranslations(py::object py_trans);
   py::object py_GetHalfHeights();
 
   // not supported

--- a/src/simulation/bulletsim_lite.h
+++ b/src/simulation/bulletsim_lite.h
@@ -124,6 +124,8 @@ public:
   BulletConstraint::Ptr py_AddConstraint(py::dict desc);
   void RemoveConstraint(BulletConstraint::Ptr cnt);
 
+  void Remove(BulletObjectPtr obj);
+
 private:
   Environment::Ptr m_env;
   RaveInstance::Ptr m_rave;

--- a/src/simulation/bulletsimpy.cpp
+++ b/src/simulation/bulletsimpy.cpp
@@ -69,6 +69,7 @@ BOOST_PYTHON_MODULE(cbulletsimpy) {
     .def("AddConstraint", &bs::BulletEnvironment::py_AddConstraint)
     .def("RemoveConstraint", &bs::BulletEnvironment::RemoveConstraint)
     .def("Remove", &bs::BulletEnvironment::Remove)
+    .def("Add", &bs::BulletEnvironment::Add)
     ;
 
   py::class_<bs::CapsuleRopeParams>("CapsuleRopeParams")
@@ -84,6 +85,9 @@ BOOST_PYTHON_MODULE(cbulletsimpy) {
     .def("GetNodes", &bs::CapsuleRope::py_GetNodes)
     .def("GetControlPoints", &bs::CapsuleRope::py_GetControlPoints)
     .def("GetRotations", &bs::CapsuleRope::py_GetRotations)
+    .def("SetRotations", &bs::CapsuleRope::py_SetRotations)
+    .def("GetTranslations", &bs::CapsuleRope::py_GetTranslations)
+    .def("SetTranslations", &bs::CapsuleRope::py_SetTranslations)
     .def("GetHalfHeights", &bs::CapsuleRope::py_GetHalfHeights)
     ;
 

--- a/src/simulation/bulletsimpy.cpp
+++ b/src/simulation/bulletsimpy.cpp
@@ -68,6 +68,7 @@ BOOST_PYTHON_MODULE(cbulletsimpy) {
     .def("SetContactDistance", &bs::BulletEnvironment::SetContactDistance)
     .def("AddConstraint", &bs::BulletEnvironment::py_AddConstraint)
     .def("RemoveConstraint", &bs::BulletEnvironment::RemoveConstraint)
+    .def("Remove", &bs::BulletEnvironment::Remove)
     ;
 
   py::class_<bs::CapsuleRopeParams>("CapsuleRopeParams")

--- a/src/simulation/rope.cpp
+++ b/src/simulation/rope.cpp
@@ -91,6 +91,34 @@ vector<btMatrix3x3> CapsuleRope_getRotations(const vector<btRigidBody*> &capsule
   return out;
 }
 
+void CapsuleRope_setRotations(const vector<btRigidBody*> &capsules, const vector<btMatrix3x3>& rots) {
+  for (int i=0; i < capsules.size(); i++) {
+    btRigidBody* body = capsules[i];
+    btTransform tf = body->getCenterOfMassTransform();
+    tf.setBasis(rots[i]);
+    body->setCenterOfMassTransform(tf);
+  }
+}
+
+vector<btVector3> CapsuleRope_getTranslations(const vector<btRigidBody*> &capsules) {
+  vector<btVector3> out;
+  for (int i=0; i < capsules.size(); i++) {
+    btRigidBody* body = capsules[i];
+    btTransform tf = body->getCenterOfMassTransform();
+    out.push_back(tf.getOrigin());
+  }
+  return out;
+}
+
+void CapsuleRope_setTranslations(const vector<btRigidBody*> &capsules, const vector<btVector3>& trans) {
+  for (int i=0; i < capsules.size(); i++) {
+    btRigidBody* body = capsules[i];
+    btTransform tf = body->getCenterOfMassTransform();
+    tf.setOrigin(trans[i]);
+    body->setCenterOfMassTransform(tf);
+  }
+}
+
 vector<float> CapsuleRope_getHalfHeights(const vector<btRigidBody*> &capsules) {
   vector<float> out;
   for (int i=0; i < capsules.size(); i++) {
@@ -182,6 +210,18 @@ vector<btVector3> CapsuleRope::getControlPoints() {
 
 vector<btMatrix3x3> CapsuleRope::getRotations() {
   return CapsuleRope_getRotations(children_rigidBodies);
+}
+
+void CapsuleRope::setRotations(const vector<btMatrix3x3>& rots) {
+  return CapsuleRope_setRotations(children_rigidBodies, rots);
+}
+
+vector<btVector3> CapsuleRope::getTranslations() {
+  return CapsuleRope_getTranslations(children_rigidBodies);
+}
+
+void CapsuleRope::setTranslations(const vector<btVector3>& trans) {
+  return CapsuleRope_setTranslations(children_rigidBodies, trans);
 }
 
 vector<float> CapsuleRope::getHalfHeights() {

--- a/src/simulation/rope.h
+++ b/src/simulation/rope.h
@@ -11,6 +11,9 @@ void CapsuleRope_createRopeTransforms(vector<btTransform>& transforms, vector<bt
 vector<btVector3> CapsuleRope_getNodes(const vector<btRigidBody*> &capsules);
 vector<btVector3> CapsuleRope_getControlPoints(const vector<btRigidBody*> &capsules);
 vector<btMatrix3x3> CapsuleRope_getRotations(const vector<btRigidBody*> &capsules);
+void CapsuleRope_setRotations(const vector<btRigidBody*> &capsules, const vector<btMatrix3x3>& rots);
+vector<btVector3> CapsuleRope_getTranslations(const vector<btRigidBody*> &capsules);
+void CapsuleRope_setTranslations(const vector<btRigidBody*> &capsules, const vector<btVector3>& trans);
 vector<float> CapsuleRope_getHalfHeights(const vector<btRigidBody*> &capsules);
 
 class CapsuleRope : public CompoundObject<BulletObject> {
@@ -34,5 +37,8 @@ public:
   std::vector<btVector3> getNodes();
   std::vector<btVector3> getControlPoints();
   vector<btMatrix3x3> getRotations();
+  void setRotations(const vector<btMatrix3x3>& rots);
+  vector<btVector3> getTranslations();
+  void setTranslations(const vector<btVector3>& trans);
   vector<float> getHalfHeights();
 };


### PR DESCRIPTION
- Add/Remove python interface for adding/removing bullet objects from the simulation environment
- Get/Set rope capsule Rotations/Translations python interface for saving and restoring rope state (it is numerically unstable to Get/Set ControlPoints repeatedly)
